### PR TITLE
Turn all list   opaque structures

### DIFF
--- a/examples/zk_c_dlist/begin_end.c
+++ b/examples/zk_c_dlist/begin_end.c
@@ -6,12 +6,14 @@
 void print_list(void *data, void *user_data)
 {
 	ZK_UNUSED(user_data);
-	printf("data: %s\n", (char *)data);
+	if (data != NULL)
+		printf("data: %s\n", (char *)data);
 }
 
 int main()
 {
 	zk_c_dlist *list = NULL, *begin = NULL, *end = NULL;
+	void *node_data = NULL;
 
 	zk_push_back(&list, "top");
 	zk_push_back(&list, "middle");
@@ -21,11 +23,22 @@ int main()
 	end = zk_end(list);
 
 	// Uses begin and end to iterate the list.
-	for (; begin != end; begin = begin->next) {
-		print_list(begin->data, NULL);
+	while (begin != end) {
+		if (zk_get_data(begin, &node_data) != ZK_OK || node_data == NULL)
+			printf("Error getting data from node.");
+		else
+			print_list(node_data, NULL);
+
+		if (zk_next(begin, &begin) != ZK_OK) {
+			printf("Error getting next node.");
+			break;
+		}
 	}
 	// print last element
-	print_list(end->data, NULL);
+	if (zk_get_data(end, &node_data) != ZK_OK || node_data == NULL)
+		printf("Error getting data from node.");
+	else
+		print_list(node_data, NULL);
 
 	// frees list
 	zk_free(&list, NULL);

--- a/examples/zk_c_slist/begin_end.c
+++ b/examples/zk_c_slist/begin_end.c
@@ -12,6 +12,7 @@ void print_list(void *data, void *user_data)
 int main()
 {
 	zk_c_slist *list = NULL;
+	void *data = NULL;
 
 	zk_push_back(&list, "top");
 	zk_push_back(&list, "middle");
@@ -21,11 +22,14 @@ int main()
 	zk_c_slist *end = zk_end(list);
 
 	// Uses begin and end to iterate the list.
-	for (; begin != end; begin = begin->next) {
-		print_list(begin->data, NULL);
+	while (begin != end) {
+		zk_get_data(begin, &data);
+		print_list(data, NULL);
+		zk_next(begin, &begin);
 	}
 	// print last element
-	print_list(end->data, NULL);
+	zk_get_data(begin, &data);
+	print_list(data, NULL);
 
 	// frees list
 	zk_free(&list, NULL);

--- a/examples/zk_dlist/begin_end.c
+++ b/examples/zk_dlist/begin_end.c
@@ -21,8 +21,15 @@ int main()
 	zk_dlist *end = zk_end(list);
 
 	// Uses begin and end to iterate the list.
-	for (; begin != end; begin = begin->next) {
-		print_list(begin->data, NULL);
+	while (begin != end) {
+		void *data = NULL;
+		if (zk_get_data(begin, &data) != ZK_OK)
+			break;
+
+		print_list(data, NULL);
+
+		if (zk_next(begin, &begin) != ZK_OK)
+			break;
 	}
 
 	// frees list

--- a/examples/zk_slist/begin_end.c
+++ b/examples/zk_slist/begin_end.c
@@ -21,8 +21,15 @@ int main()
 	zk_slist *end = zk_end(list);
 
 	// Uses begin and end to iterate the list.
-	for (; begin != end; begin = begin->next) {
-		print_list(begin->data, NULL);
+	while (begin != end) {
+		void *data = NULL;
+		if (zk_get_data(begin, &data) != ZK_OK)
+			break;
+
+		print_list(data, NULL);
+
+		if (zk_next(begin, &begin) != ZK_OK)
+			break;
 	}
 
 	// frees list

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,14 @@ project(
     default_options: ['warning_level=3', 'werror=true', 'c_std=gnu11', 'cpp_std=gnu++17', 'optimization=g'],
 )
 
+project_cflags = [
+    '-Wno-unused-but-set-parameter',
+]
+
+cc = meson.get_compiler('c')
+
+add_project_arguments(cc.get_supported_arguments(project_cflags), language : 'c')
+
 #  options
 unit_test = get_option('unit_test')
 

--- a/src/zk_c_dlist/zk_c_dlist.c
+++ b/src/zk_c_dlist/zk_c_dlist.c
@@ -2,6 +2,15 @@
 
 #include "zk_c_dlist/zk_c_dlist.h"
 
+/**
+ * @brief A circular doubly linked list node.
+ */
+struct zk_c_dlist {
+	void *data;
+	struct zk_c_dlist *prev;
+	struct zk_c_dlist *next;
+};
+
 // Private functions
 static void _zk_c_dlist_free(zk_c_dlist **node, zk_destructor_t const func)
 {
@@ -51,7 +60,38 @@ void zk_c_dlist_free(zk_c_dlist **list_p, zk_destructor_t const func)
 	}
 }
 
+// Element access
+zk_status zk_c_dlist_get_data(const zk_c_dlist *const list, void **data)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*data = list->data;
+
+	return ZK_OK;
+}
+
 // Iterators
+zk_status zk_c_dlist_next(const zk_c_dlist *const list, zk_c_dlist **next)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*next = list->next;
+
+	return ZK_OK;
+}
+
+zk_status zk_c_dlist_prev(const zk_c_dlist *const list, zk_c_dlist **prev)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*prev = list->prev;
+
+	return ZK_OK;
+}
+
 zk_c_dlist *zk_c_dlist_begin(zk_c_dlist *list)
 {
 	return list;

--- a/src/zk_c_dlist/zk_c_dlist.h
+++ b/src/zk_c_dlist/zk_c_dlist.h
@@ -3,11 +3,7 @@
 
 #include "zk_common/zk_common.h"
 
-typedef struct zk_c_dlist {
-	void *data;
-	struct zk_c_dlist *prev;
-	struct zk_c_dlist *next;
-} zk_c_dlist;
+typedef struct zk_c_dlist zk_c_dlist;
 
 // Constructor
 zk_status zk_c_dlist_new_node(zk_c_dlist **node_p, void *const data);
@@ -15,7 +11,14 @@ zk_status zk_c_dlist_new_node(zk_c_dlist **node_p, void *const data);
 // Destructor
 void zk_c_dlist_free(zk_c_dlist **list_p, zk_destructor_t const func);
 
+// Element access
+zk_status zk_c_dlist_get_data(const zk_c_dlist *const list, void **data);
+
 // Iterators
+zk_status zk_c_dlist_next(const zk_c_dlist *const list, zk_c_dlist **next);
+
+zk_status zk_c_dlist_prev(const zk_c_dlist *const list, zk_c_dlist **prev);
+
 zk_c_dlist *zk_c_dlist_begin(zk_c_dlist *list);
 
 zk_c_dlist *zk_c_dlist_end(zk_c_dlist *list);

--- a/src/zk_c_slist/zk_c_slist.c
+++ b/src/zk_c_slist/zk_c_slist.c
@@ -2,6 +2,16 @@
 
 #include "zk_c_slist/zk_c_slist.h"
 
+/**
+ * @brief Circular singly linked list struct
+ * Internally this list is managed in a way that it always points to the last node for efficient operations.
+ */
+
+struct zk_c_slist {
+	void *data;
+	struct zk_c_slist *next;
+};
+
 // Private functions
 static void _zk_c_slist_free(zk_c_slist **node, zk_destructor_t const func)
 {
@@ -50,7 +60,28 @@ void zk_c_slist_free(zk_c_slist **list_p, zk_destructor_t const func)
 	}
 }
 
+// Element access
+zk_status zk_c_slist_get_data(const zk_c_slist *const list, void **data)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*data = list->data;
+
+	return ZK_OK;
+}
+
 // Iterators
+zk_status zk_c_slist_next(const zk_c_slist *const list, zk_c_slist **next)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*next = list->next;
+
+	return ZK_OK;
+}
+
 zk_c_slist *zk_c_slist_begin(zk_c_slist *list)
 {
 	return list != NULL ? list->next : list;

--- a/src/zk_c_slist/zk_c_slist.h
+++ b/src/zk_c_slist/zk_c_slist.h
@@ -3,10 +3,7 @@
 
 #include "zk_common/zk_common.h"
 
-typedef struct zk_c_slist {
-	void *data;
-	struct zk_c_slist *next;
-} zk_c_slist;
+typedef struct zk_c_slist zk_c_slist;
 
 // Constructor
 zk_status zk_c_slist_new_node(zk_c_slist **node_p, void *const data);
@@ -14,7 +11,12 @@ zk_status zk_c_slist_new_node(zk_c_slist **node_p, void *const data);
 // Destructor
 void zk_c_slist_free(zk_c_slist **list_p, zk_destructor_t const func);
 
+// Element access
+zk_status zk_c_slist_get_data(const zk_c_slist *const list, void **data);
+
 // Iterators
+zk_status zk_c_slist_next(const zk_c_slist *const list, zk_c_slist **next);
+
 zk_c_slist *zk_c_slist_begin(zk_c_slist *list);
 
 zk_c_slist *zk_c_slist_end(zk_c_slist *list);

--- a/src/zk_container/zk_container.h
+++ b/src/zk_container/zk_container.h
@@ -18,10 +18,11 @@
 		(CONTAINER, FUNC)
 
 // Element access
-#define zk_get_data(CONTAINER, DATA)            \
-	_Generic((CONTAINER),                   \
-		zk_slist * : zk_slist_get_data, \
-		zk_dlist * : zk_dlist_get_data) \
+#define zk_get_data(CONTAINER, DATA)                \
+	_Generic((CONTAINER),                       \
+		zk_slist *   : zk_slist_get_data,   \
+		zk_dlist *   : zk_dlist_get_data,   \
+		zk_c_slist * : zk_c_slist_get_data) \
 		(CONTAINER, DATA)
 
 // Iterators
@@ -54,10 +55,11 @@
 		zk_c_dlist * : zk_c_dlist_end) \
 		(CONTAINER)
 
-#define zk_next(CONTAINER, NEXT)            \
-	_Generic((CONTAINER),               \
-		zk_slist * : zk_slist_next, \
-		zk_dlist * : zk_dlist_next) \
+#define zk_next(CONTAINER, NEXT)                \
+	_Generic((CONTAINER),                   \
+		zk_slist *   : zk_slist_next,   \
+		zk_dlist *   : zk_dlist_next,   \
+		zk_c_slist * : zk_c_slist_next) \
 		(CONTAINER, NEXT)
 
 #define zk_prev(CONTAINER, NEXT)            \

--- a/src/zk_container/zk_container.h
+++ b/src/zk_container/zk_container.h
@@ -20,7 +20,8 @@
 // Element access
 #define zk_get_data(CONTAINER, DATA)            \
 	_Generic((CONTAINER),                   \
-		zk_slist * : zk_slist_get_data) \
+		zk_slist * : zk_slist_get_data, \
+		zk_dlist * : zk_dlist_get_data) \
 		(CONTAINER, DATA)
 
 // Iterators
@@ -50,12 +51,18 @@
 		zk_slist *   : zk_slist_end,   \
 		zk_dlist *   : zk_dlist_end,   \
 		zk_c_slist * : zk_c_slist_end, \
-		zk_c_dlist * :zk_c_dlist_end)  \
+		zk_c_dlist * : zk_c_dlist_end) \
 		(CONTAINER)
 
 #define zk_next(CONTAINER, NEXT)            \
 	_Generic((CONTAINER),               \
-		zk_slist * : zk_slist_next) \
+		zk_slist * : zk_slist_next, \
+		zk_dlist * : zk_dlist_next) \
+		(CONTAINER, NEXT)
+
+#define zk_prev(CONTAINER, NEXT)            \
+	_Generic((CONTAINER),               \
+		zk_dlist * : zk_dlist_prev) \
 		(CONTAINER, NEXT)
 
 // Modifiers

--- a/src/zk_container/zk_container.h
+++ b/src/zk_container/zk_container.h
@@ -18,6 +18,12 @@
 		zk_c_dlist ** : zk_c_dlist_free) \
 		(CONTAINER, FUNC)
 
+// Element access
+#define zk_get_data(CONTAINER, DATA)            \
+	_Generic((CONTAINER),                   \
+		zk_slist * : zk_slist_get_data) \
+		(CONTAINER, DATA)
+
 // Iterators
 #define zk_for_each(CONTAINER, FUNC, USER_DATA)     \
 	_Generic((CONTAINER),                       \
@@ -42,6 +48,11 @@
 		zk_c_slist * : zk_c_slist_end, \
 		zk_c_dlist * : zk_c_dlist_end) \
 		(CONTAINER)
+
+#define zk_next(CONTAINER, NEXT)            \
+	_Generic((CONTAINER),               \
+		zk_slist * : zk_slist_next) \
+		(CONTAINER, NEXT)
 
 // Modifiers
 #define zk_pop_back(CONTAINER, FUNC)                 \

--- a/src/zk_container/zk_container.h
+++ b/src/zk_container/zk_container.h
@@ -8,7 +8,6 @@
 
 // clang-format off
 
-
 // Destructor
 #define zk_free(CONTAINER, FUNC)                 \
 	_Generic((CONTAINER),                    \
@@ -31,7 +30,12 @@
 		zk_dlist *   : zk_dlist_for_each,   \
 		zk_c_slist * : zk_c_slist_for_each, \
 		zk_c_dlist * : zk_c_dlist_for_each) \
-		(zk_begin(CONTAINER), zk_end(CONTAINER), FUNC, USER_DATA)
+		(                                   \
+			zk_begin(CONTAINER),        \
+			zk_end(CONTAINER),          \
+			FUNC,                       \
+			USER_DATA                   \
+		)
 
 #define zk_begin(CONTAINER)                      \
 	_Generic((CONTAINER),                    \
@@ -46,7 +50,7 @@
 		zk_slist *   : zk_slist_end,   \
 		zk_dlist *   : zk_dlist_end,   \
 		zk_c_slist * : zk_c_slist_end, \
-		zk_c_dlist * : zk_c_dlist_end) \
+		zk_c_dlist * :zk_c_dlist_end)  \
 		(CONTAINER)
 
 #define zk_next(CONTAINER, NEXT)            \
@@ -87,5 +91,4 @@
 		zk_c_dlist ** : zk_c_dlist_push_front)   \
 		(CONTAINER, DATA)
 
-// clang-format on
 #endif

--- a/src/zk_container/zk_container.h
+++ b/src/zk_container/zk_container.h
@@ -22,7 +22,8 @@
 	_Generic((CONTAINER),                       \
 		zk_slist *   : zk_slist_get_data,   \
 		zk_dlist *   : zk_dlist_get_data,   \
-		zk_c_slist * : zk_c_slist_get_data) \
+		zk_c_slist * : zk_c_slist_get_data, \
+		zk_c_dlist * : zk_c_dlist_get_data) \
 		(CONTAINER, DATA)
 
 // Iterators
@@ -59,12 +60,14 @@
 	_Generic((CONTAINER),                   \
 		zk_slist *   : zk_slist_next,   \
 		zk_dlist *   : zk_dlist_next,   \
-		zk_c_slist * : zk_c_slist_next) \
+		zk_c_slist * : zk_c_slist_next, \
+		zk_c_dlist * : zk_c_dlist_next) \
 		(CONTAINER, NEXT)
 
-#define zk_prev(CONTAINER, NEXT)            \
-	_Generic((CONTAINER),               \
-		zk_dlist * : zk_dlist_prev) \
+#define zk_prev(CONTAINER, NEXT)                \
+	_Generic((CONTAINER),                   \
+		zk_dlist * : zk_dlist_prev,     \
+		zk_c_dlist * : zk_c_dlist_prev) \
 		(CONTAINER, NEXT)
 
 // Modifiers

--- a/src/zk_dlist/zk_dlist.c
+++ b/src/zk_dlist/zk_dlist.c
@@ -2,6 +2,15 @@
 
 #include "zk_dlist/zk_dlist.h"
 
+/**
+ * @brief: Doubly linked list struct
+ */
+struct zk_dlist {
+	void *data;
+	struct zk_dlist *prev;
+	struct zk_dlist *next;
+};
+
 // SECTION: Private functions
 static zk_dlist *zk_dlist_back(zk_dlist *list)
 {
@@ -59,7 +68,38 @@ void zk_dlist_free(zk_dlist **list_p, zk_destructor_t const func)
 	}
 }
 
+// Element access
+zk_status zk_dlist_get_data(const zk_dlist *const list, void **data)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*data = list->data;
+
+	return ZK_OK;
+}
+
 // Iterators
+zk_status zk_dlist_next(const zk_dlist *const list, zk_dlist **next)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*next = list->next;
+
+	return ZK_OK;
+}
+
+zk_status zk_dlist_prev(const zk_dlist *const list, zk_dlist **prev)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*prev = list->prev;
+
+	return ZK_OK;
+}
+
 zk_dlist *zk_dlist_begin(zk_dlist *list)
 {
 	return list;

--- a/src/zk_dlist/zk_dlist.h
+++ b/src/zk_dlist/zk_dlist.h
@@ -3,11 +3,7 @@
 
 #include "zk_common/zk_common.h"
 
-typedef struct zk_dlist {
-	void *data;
-	struct zk_dlist *prev;
-	struct zk_dlist *next;
-} zk_dlist;
+typedef struct zk_dlist zk_dlist;
 
 // Constructor
 zk_status zk_dlist_new_node(zk_dlist **node_p, void *const data);
@@ -15,7 +11,14 @@ zk_status zk_dlist_new_node(zk_dlist **node_p, void *const data);
 // Destructor
 void zk_dlist_free(zk_dlist **list_p, zk_destructor_t const func);
 
+// Element access
+zk_status zk_dlist_get_data(const zk_dlist *const list, void **data);
+
 // Iterators
+zk_status zk_dlist_next(const zk_dlist *const list, zk_dlist **next);
+
+zk_status zk_dlist_prev(const zk_dlist *const list, zk_dlist **prev);
+
 zk_dlist *zk_dlist_begin(zk_dlist *list);
 
 zk_dlist *zk_dlist_end(zk_dlist *list);

--- a/src/zk_slist/zk_slist.c
+++ b/src/zk_slist/zk_slist.c
@@ -3,7 +3,7 @@
 #include "zk_slist/zk_slist.h"
 
 /**
- * @brief Single linked list struct
+ * @brief Singly linked list struct
  *
  */
 struct zk_slist {

--- a/src/zk_slist/zk_slist.c
+++ b/src/zk_slist/zk_slist.c
@@ -2,6 +2,15 @@
 
 #include "zk_slist/zk_slist.h"
 
+/**
+ * @brief Single linked list struct
+ *
+ */
+struct zk_slist {
+	void *data;
+	struct zk_slist *next;
+};
+
 // Private functions
 static void _zk_slist_free(zk_slist **node, zk_destructor_t func)
 {
@@ -54,7 +63,28 @@ void zk_slist_free(zk_slist **list_p, zk_destructor_t const func)
 	}
 }
 
+// Element access
+zk_status zk_slist_get_data(const zk_slist *const list, void **data)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*data = list->data;
+
+	return ZK_OK;
+}
+
 // Iterators
+zk_status zk_slist_next(const zk_slist *const list, zk_slist **next)
+{
+	if (list == NULL)
+		return ZK_INVALID_ARGUMENT;
+
+	*next = list->next;
+
+	return ZK_OK;
+}
+
 zk_slist *zk_slist_begin(zk_slist *list)
 {
 	return list;

--- a/src/zk_slist/zk_slist.h
+++ b/src/zk_slist/zk_slist.h
@@ -4,22 +4,19 @@
 
 #include "zk_common/zk_common.h"
 
-/**
- * @brief Single linked list struct
- *
- */
-typedef struct zk_slist {
-	void *data;
-	struct zk_slist *next;
-} zk_slist;
-
+typedef struct zk_slist zk_slist;
 // Constructor
 zk_status zk_slist_new_node(zk_slist **node_p, void *const data);
 
 // Destructor
 void zk_slist_free(zk_slist **list_p, zk_destructor_t const func);
 
+// Element access
+zk_status zk_slist_get_data(const zk_slist *const list, void **data);
+
 // Iterators
+zk_status zk_slist_next(const zk_slist *const list, zk_slist **next);
+
 zk_slist *zk_slist_begin(zk_slist *list);
 
 zk_slist *zk_slist_end(zk_slist *list);


### PR DESCRIPTION
Add function zk_get_data() and zk_next() for zk_slist

Disable compiler warning for unused-but-set-parameter. This is needed as some functions just set some parameters but do not use it. Examples are zk_get_data() and zk_next()